### PR TITLE
Minor fixes

### DIFF
--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -21,7 +21,7 @@ if [ $(id -u) != 0 ]; then
 	echo "Error!"
 	echo ""
 	echo "You need to be root to run this script."
-	exit
+	exit 1
 fi
 
 # Vars for stuff
@@ -141,7 +141,7 @@ if [ $DNSCRYPTINST == true ]; then
 		echo "from the system and run this script again."
 		echo ""
 		echo "Quitting."
-		exit
+		exit 1
 	fi
 else
 	if nc -z -w1 127.0.0.1 53; then
@@ -155,7 +155,7 @@ else
 		echo "or make it listen on another IP than 127.0.0.1."
 		echo ""
 		echo "Quitting."
-		exit
+		exit 1
 	else
 		echo ""
 		echo "Welcome to dnscrypt-autoinstall script."


### PR DESCRIPTION
Use a more reliable check for root user for e.g. servers with "root" renamed away from script kiddies, and report errors in exit code so that they can be easily checked for.
