### PR TITLE
dnscrypt user unable to chroot

### DIFF
--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -120,7 +120,7 @@ if [ $DNSCRYPTINST == true ]; then
 			rm /etc/init.d/dnscrypt-proxy
 			rm /usr/local/sbin/dnscrypt-proxy
 			deluser dnscrypt
-			rm -rf /etc/dnscrypt/run
+			rm -rf /etc/dnscrypt
 			mv /etc/resolv.conf-dnscryptbak /etc/resolv.conf
 			echo "DNSCrypt has been removed. Quitting."
 			exit


### PR DESCRIPTION
While making a few changes to my network, I've noticed DNSCrypt hasn't run for three days. 

Launching it via `/etc/init.d/dnscrypt-proxy` or `dnscrypt-proxy -d -u dnscrypt` gave no errors, but no launched process either. 

/var/log/daemon.log

`Apr  8 02:29:43 arbellen dnscrypt-proxy[2112]: Generating a new key pair
Apr  8 02:29:43 arbellen dnscrypt-proxy[2112]: Done
Apr  8 02:29:44 arbellen dnscrypt-proxy[2112]: Unable to chroot to [/var/run/dnscrypt]`

ls -l /var/run
lrwxrwxrwx 1 root root 4 apr  6 20:12 /var/run -> /run

Deleting the user and making a new one with `adduser` and `/run` home made it work again. chown/mkdir was not needed

`drwxr-xr-x  2 dnscrypt   dnscrypt     40 apr 11 00:56 dnscrypt`

I've also added some safety checks (/bin/false, disabled pw/login).

edit: sorry for messy commits :/
