### PR TITLE
github redirect and curl

### DIFF
--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -68,7 +68,7 @@ function config_interface {
 }
 
 function config_do {
-	curl -o initscript-$WHICHRESOLVER.sh https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts/initscript-$WHICHRESOLVER.sh
+	curl -Lo initscript-$WHICHRESOLVER.sh https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts/initscript-$WHICHRESOLVER.sh
 	if [ $DNSCRYPTCONF == true ]; then
 		/etc/init.d/dnscrypt-proxy stop
 		update-rc.d -f dnscrypt-proxy remove


### PR DESCRIPTION
github now uses a redirect, so curl only loads the initscripts with -L

http://curl.haxx.se/docs/faq.html#How_do_I_tell_curl_to_follow_HTT
