### PR TITLE
Script for Red Hat based distributions

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -2,7 +2,7 @@
 
 ### 
 # Installation and autoconfigure script for Red Hat-based systems (Fedora, CentOS, 
-# Scientific Linux and dnscrypt).
+# Scientific Linux) and dnscrypt.
 #
 # This script will install pre-req's, make & install dnscrypt and finally set it up
 # as a daemon service that runs on system startup. It also gives you the option to


### PR DESCRIPTION
Tested on CentOS 6.5. You needn't compile libsodium on Fedora 19/20, so there's a check for that
