### PR TITLE
Update to latest dnscrypt-proxy/libsodium and enable ephemeral keys - fixes #48

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -26,10 +26,10 @@ fi
 LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
-LSODIUMVER=1.0.2
-DNSCRYPTVER=1.4.3
-LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.2"
-DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.4.3"
+LSODIUMVER=1.0.3
+DNSCRYPTVER=1.5.0
+LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.3"
+DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.5.0"
 GPGURL_LS="https://download.libsodium.org/libsodium/releases"
 GPGURL_DC="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
@@ -248,13 +248,13 @@ EOF
 		fi
 		
 		# Continue with dnscrypt installation 
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2 $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
 		
 		# Verify signature
-		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
+		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
 		
-		tar -zxf dnscrypt-proxy-$DNSCRYPTVER.tar.gz
+		tar -jxf dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
 		pushd dnscrypt-proxy-$DNSCRYPTVER
 		./configure && make && \
 		sudo bash <<EOF 

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -27,10 +27,10 @@ fi
 LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
-LSODIUMVER=1.0.2
-DNSCRYPTVER=1.4.3
-LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.2"
-DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.4.3"
+LSODIUMVER=1.0.3
+DNSCRYPTVER=1.5.0
+LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.3"
+DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.5.0"
 GPGURL_LS="https://download.libsodium.org/libsodium/releases"
 GPGURL_DC="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
@@ -244,13 +244,13 @@ EOF
 		fi
 		
 		# Continue with dnscrypt installation
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2 $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
 		
 		# Verify signature
-		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
+		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
 		
-		tar -zxf dnscrypt-proxy-$DNSCRYPTVER.tar.gz
+		tar -jxf dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
 		pushd dnscrypt-proxy-$DNSCRYPTVER
 		./configure && make && \
 		sudo bash <<EOF

--- a/init-scripts/initscript-cloudns.sh
+++ b/init-scripts/initscript-cloudns.sh
@@ -24,8 +24,8 @@ PKEY2=67A4:323E:581F:79B9:BC54:825F:54FE:1025:8B4F:37EB:0D07:0BCE:4010:6195:D94F
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
-	$DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
+	$DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
     ;;
   stop)
     echo "Stopping $NAME"

--- a/init-scripts/initscript-dnscrypteu.sh
+++ b/init-scripts/initscript-dnscrypteu.sh
@@ -24,8 +24,8 @@ PKEY2=67C0:0F2C:21C5:5481:45DD:7CB4:6A27:1AF2:EB96:9931:40A3:09B6:2B8D:1653:1185
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
-	$DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
+	$DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
     ;;
   stop)
     echo "Stopping $NAME"

--- a/init-scripts/initscript-opendns.sh
+++ b/init-scripts/initscript-opendns.sh
@@ -18,7 +18,7 @@ NAME=dnscrypt-proxy
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt -R OpenDNS
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt -R OpenDNS
     ;;
   stop)
     echo "Stopping $NAME"

--- a/init-scripts/initscript-openniceu.sh
+++ b/init-scripts/initscript-openniceu.sh
@@ -24,8 +24,8 @@ PKEY2=E864:80D9:DFBD:9DB4:58EA:8063:292F:EC41:9126:8394:BC44:FAB8:4B6E:B104:8C3B
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
-	$DAEMON --daemonize --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.1 --resolver-address=$ADDRESS1 --provider-name=$PNAME1 --provider-key=$PKEY1
+	$DAEMON --daemonize --ephemeral-keys --user=dnscrypt --local-address=127.0.0.2 --resolver-address=$ADDRESS2 --provider-name=$PNAME2 --provider-key=$PKEY2
     ;;
   stop)
     echo "Stopping $NAME"

--- a/init-scripts/initscript-opennicjp.sh
+++ b/init-scripts/initscript-opennicjp.sh
@@ -21,7 +21,7 @@ PKEY=8768:C3DB:F70A:FBC6:3B64:8630:8167:2FD4:EE6F:E175:ECFD:46C9:22FC:7674:A1AC:
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt --resolver-address=$ADDRESS --provider-name=$PNAME --provider-key=$PKEY
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt --resolver-address=$ADDRESS --provider-name=$PNAME --provider-key=$PKEY
     ;;
   stop)
     echo "Stopping $NAME"

--- a/init-scripts/initscript-soltysiak.sh
+++ b/init-scripts/initscript-soltysiak.sh
@@ -21,7 +21,7 @@ PKEY=25C4:E188:2915:4697:8F9C:2BBD:B6A7:AFA4:01ED:A051:0508:5D53:03E7:1928:C066:
 case "$1" in
   start)
     echo "Starting $NAME"
-    $DAEMON --daemonize --user=dnscrypt --resolver-address=$ADDRESS --provider-name=$PNAME --provider-key=$PKEY
+    $DAEMON --daemonize --ephemeral-keys --user=dnscrypt --resolver-address=$ADDRESS --provider-name=$PNAME --provider-key=$PKEY
     ;;
   stop)
     echo "Stopping $NAME"


### PR DESCRIPTION
Summary of changes:
- Update to use latest version of dnscrypt-proxy, 1.5.0 (prerequisite for ephemeral keys).
- Update to use latest version of libsodium, 1.0.3.
- Enable ephemeral keys in the init-scripts for each DNSCrypt service (fixes #48).

I tested the changes using `dnscrypt-autoinstall.sh` and can confirm they're working.