### PR TITLE
Use GPG key fingerprint instead of 32 bit keyid

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -223,7 +223,7 @@ EOF
 		yum install -y libsodium-devel && LSODIUMINST=true
 		
 		# Import GPG key to verify files
-		import_gpgkey BA709FE1
+		import_gpgkey 54A2B8892CC3D6A597B92B6C210627AABA709FE1
 		
 		# Is libsodium installed?
 		if [ "$LSODIUMINST" == "false" ]; then

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -222,7 +222,7 @@ EOF
 		pushd "$TMPDIR"
 		
 		# Import GPG key to verify files
-		import_gpgkey BA709FE1
+		import_gpgkey 54A2B8892CC3D6A597B92B6C210627AABA709FE1
 		
 		# Is libsodium installed?
 		if [ "$LSODIUMINST" == "false" ]; then


### PR DESCRIPTION
Better security: Same GPG key as before, but now imported with its full fingerprint instead of short keyid to prevent potential attacks based on keyid collisions (see https://evil32.com/ for proof of concept).

Also, the GnuPG documentation [recommends](https://www.gnupg.org/documentation/manuals/gnupg-devel/Specify-a-User-ID.html) using fingerprints for automated processing:

> There are different ways to specify a user ID to GnuPG. Some of them are only valid for gpg others are only good for gpgsm. Here is the entire list of ways to specify a key:
> - By key Id. ... The use of key Ids is just a shortcut, for all automated processing the fingerprint should be used. ...
> - By fingerprint. ... The best way to specify a key Id is by using the fingerprint. This avoids any ambiguities in case that there are duplicated key IDs. ...

I've tested with `dnscrypt-autoinstall.sh` and can confirm it works. The signatures pass verification.