### PR TITLE
Add ephemeral keys to systemd service

### DIFF
--- a/systemd/dnscrypt-proxy-backup.service
+++ b/systemd/dnscrypt-proxy-backup.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/dnscrypt-proxy \
 	--provider-name=${DNSCRYPT_PROVIDER_NAME2} \
 	--provider-key=${DNSCRYPT_PROVIDER_KEY2} \
 	--user=${DNSCRYPT_USER}
+	--ephemeral-keys
 Restart=on-abort
 
 [Install]

--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/dnscrypt-proxy \
 	--provider-name=${DNSCRYPT_PROVIDER_NAME} \
 	--provider-key=${DNSCRYPT_PROVIDER_KEY} \
 	--user=${DNSCRYPT_USER}
+	--ephemeral-keys
 Restart=on-abort
 
 [Install]


### PR DESCRIPTION
Adds the `--ephemeral-keys` flag to the systemd service scripts.
I overlooked this earlier when fixing issue #48 in pull request #49.