### PR TITLE
Automatically download latest versions of dnscrypt/libsodium - fixes #44

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -29,8 +29,8 @@ DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
 DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
-LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
-DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | awk -F'(.tar|libsodium-)' '/libsodium-1/ {v=$2}; END {print v}')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | awk -F'(.tar|proxy-)' '/proxy-1/ {v=$2}; END {print v}')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec

--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -26,13 +26,11 @@ fi
 LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
-LSODIUMVER=1.0.3
-DNSCRYPTVER=1.5.0
-LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.3"
-DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.5.0"
-GPGURL_LS="https://download.libsodium.org/libsodium/releases"
-GPGURL_DC="http://download.dnscrypt.org/dnscrypt-proxy"
+LSODIUMURL="https://download.libsodium.org/libsodium/releases"
+DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec
@@ -237,7 +235,7 @@ EOF
 		if [ "$LSODIUMINST" == "false" ]; then
 			# Nope? Then let's get it set up
 			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz $LSODIUMURL/libsodium-$LSODIUMVER.tar.gz
-			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz.sig $GPGURL_LS/libsodium-$LSODIUMVER.tar.gz.sig
+			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz.sig $LSODIUMURL/libsodium-$LSODIUMVER.tar.gz.sig
 			
 			# Verify signature
 			verify_sig libsodium-$LSODIUMVER.tar.gz.sig
@@ -256,13 +254,13 @@ EOF
 		fi
 		
 		# Continue with dnscrypt installation 
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2 $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
 		
 		# Verify signature
-		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
+		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
 		
-		tar -jxf dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
+		tar -zxf dnscrypt-proxy-$DNSCRYPTVER.tar.gz
 		pushd dnscrypt-proxy-$DNSCRYPTVER
 		./configure && make && \
 		sudo bash <<EOF 

--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -29,8 +29,8 @@ DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
 DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
-LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
-DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -27,13 +27,11 @@ fi
 LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
-LSODIUMVER=1.0.3
-DNSCRYPTVER=1.5.0
-LSODIUMURL="https://github.com/jedisct1/libsodium/releases/download/1.0.3"
-DNSCRYPTURL="https://github.com/jedisct1/dnscrypt-proxy/releases/download/1.5.0"
-GPGURL_LS="https://download.libsodium.org/libsodium/releases"
-GPGURL_DC="http://download.dnscrypt.org/dnscrypt-proxy"
+LSODIUMURL="https://download.libsodium.org/libsodium/releases"
+DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec
@@ -236,7 +234,7 @@ EOF
 		if [ "$LSODIUMINST" == "false" ]; then
 			# Nope? Then let's get it set up
 			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz $LSODIUMURL/libsodium-$LSODIUMVER.tar.gz
-			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz.sig $GPGURL_LS/libsodium-$LSODIUMVER.tar.gz.sig
+			curl --retry 5 -Lo libsodium-$LSODIUMVER.tar.gz.sig $LSODIUMURL/libsodium-$LSODIUMVER.tar.gz.sig
 			
 			# Verify signature
 			verify_sig libsodium-$LSODIUMVER.tar.gz.sig
@@ -252,13 +250,13 @@ EOF
 		fi
 		
 		# Continue with dnscrypt installation
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2 $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
-		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig $GPGURL_DC/dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz
+		curl --retry 5 -Lo dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig $DNSCRYPTURL/dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
 		
 		# Verify signature
-		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.bz2.sig
+		verify_sig dnscrypt-proxy-$DNSCRYPTVER.tar.gz.sig
 		
-		tar -jxf dnscrypt-proxy-$DNSCRYPTVER.tar.bz2
+		tar -zxf dnscrypt-proxy-$DNSCRYPTVER.tar.gz
 		pushd dnscrypt-proxy-$DNSCRYPTVER
 		./configure && make && \
 		sudo bash <<EOF

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -30,8 +30,8 @@ DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
 DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
-LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
-DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sed 's/".*//' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -30,8 +30,8 @@ DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
 DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
-LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | grep -o 'libsodium-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
-DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | grep -o 'dnscrypt-proxy-1.[0-9].[0-9].tar.gz' | sort -u | tail -n 1 | grep -o '[0-9].[0-9].[0-9]')
+LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | awk -F'(.tar|libsodium-)' '/libsodium-1/ {v=$2}; END {print v}')
+DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | awk -F'(.tar|proxy-)' '/proxy-1/ {v=$2}; END {print v}')
 WHICHRESOLVER=dnscrypteu
 
 # /tmp may be mounted noexec


### PR DESCRIPTION
**Automatically download the latest versions of dnscrypt-proxy and libsodium.**
We no longer have to update the script every time there's a version number change, the script gets the latest version numbers automatically. It's set to stick to the 1.X.X releases only, since we'll probably need to update the whole script when either one eventually reaches 2.X.X. Fixes #44, related to #31.

**Download source files from `download.libsodium.org` and `download.dnscrypt.org`.**
This is to better facilitate automated downloading of the latest versions. While LSODIUMURL and DNSCRYPTURL were previously changed to `github.com` in #22 / #23 due to problems with the `download.libsodium.org` server, there are 4 reasons why we should switch them back to `download.libsodium.org` and `download.dnscrypt.org`:
- The script has since become dependent upon getting the PGP signature files from `download.libsodium.org` and `download.dnscrypt.org`, so it might as well get the source files there too. The signature files aren't hosted elsewhere. If the libsodium server has issues, the script will fail regardless.
- The downloads at 'https://github.com/jedisct1/dnscrypt-proxy/releases' are inconsistently released as either `.tar.gz` or `.tar.bz2`, but not both (eg. `dnscrypt-proxy-1.4.3.tar.gz`, `dnscrypt-proxy-1.5.0.tar.bz2`). But the ones at `http://download.dnscrypt.org/dnscrypt-proxy` are reliably released in both formats, which makes more sense for automated downloading of the latest version.
- For automatically getting the latest version numbers, it's easier to grep through `https://download.libsodium.org/libsodium/releases` and `http://download.dnscrypt.org/dnscrypt-proxy` than through the `github.com` release pages.
- If the server at `download.libsodium.org` is still having issues as reported in #22 / #23 nearly a year ago, then the server ought to be fixed.

I've tested the changes and can confirm they're working.