### PR TITLE
Uninstall libsodium - fixes #56

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -135,6 +135,9 @@ config_del() {
 	rm -f /usr/local/lib/pkgconfig/libsodium.pc
 	rm -fr /usr/local/include/sodium
 	
+	# Uninstall libsodium on Fedora 19/20
+	yum remove -y libsodium-devel
+	
 	# Restore backed-up resolv.conf
 	chattr -i /etc/resolv.conf
 	mv /etc/resolv.conf-dnscryptbak /etc/resolv.conf

--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -122,12 +122,20 @@ verify_sig() {
 
 config_del() {
 	sudo bash <<EOF
+	# Uninstall dnscrypt-proxy
 	/etc/init.d/dnscrypt-proxy stop
 	chkconfig --del dnscrypt-proxy
 	rm -f /etc/init.d/dnscrypt-proxy
 	rm -f /usr/local/sbin/dnscrypt-proxy
 	userdel -r dnscrypt
 	rm -rf /etc/dnscrypt
+	
+	# Uninstall libsodium
+	rm -f /usr/local/lib/libsodium.*
+	rm -f /usr/local/lib/pkgconfig/libsodium.pc
+	rm -fr /usr/local/include/sodium
+	
+	# Restore backed-up resolv.conf
 	chattr -i /etc/resolv.conf
 	mv /etc/resolv.conf-dnscryptbak /etc/resolv.conf
 EOF

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -124,12 +124,20 @@ verify_sig() {
 
 config_del() {
 	sudo bash <<EOF
+	# Uninstall dnscrypt-proxy
 	/etc/init.d/dnscrypt-proxy stop
 	update-rc.d -f dnscrypt-proxy remove
 	rm -f /etc/init.d/dnscrypt-proxy
 	rm -f /usr/local/sbin/dnscrypt-proxy
 	deluser dnscrypt
 	rm -rf /etc/dnscrypt
+	
+	# Uninstall libsodium
+	rm -f /usr/local/lib/libsodium.*
+	rm -f /usr/local/lib/pkgconfig/libsodium.pc
+	rm -fr /usr/local/include/sodium
+	
+	# Restore backed-up resolv.conf
 	chattr -i /etc/resolv.conf
 	mv /etc/resolv.conf-dnscryptbak /etc/resolv.conf
 EOF


### PR DESCRIPTION
Enable uninstallation of libsodium. As a potential fix for #56, this would allow users to install an updated version of libsodium.