### PR TITLE
 fix #54 lucaspetter/systemd-ephemeral-keys

### DIFF
--- a/systemd/dnscrypt-proxy-backup.service
+++ b/systemd/dnscrypt-proxy-backup.service
@@ -13,7 +13,7 @@ ExecStart=/usr/bin/dnscrypt-proxy \
 	--resolver-address=${DNSCRYPT_RESOLVERIP2}:${DNSCRYPT_RESOLVERPORT} \
 	--provider-name=${DNSCRYPT_PROVIDER_NAME2} \
 	--provider-key=${DNSCRYPT_PROVIDER_KEY2} \
-	--user=${DNSCRYPT_USER}
+	--user=${DNSCRYPT_USER} \
 	--ephemeral-keys
 Restart=on-abort
 

--- a/systemd/dnscrypt-proxy.service
+++ b/systemd/dnscrypt-proxy.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/dnscrypt-proxy \
 	--resolver-address=${DNSCRYPT_RESOLVERIP}:${DNSCRYPT_RESOLVERPORT} \
 	--provider-name=${DNSCRYPT_PROVIDER_NAME} \
 	--provider-key=${DNSCRYPT_PROVIDER_KEY} \
-	--user=${DNSCRYPT_USER}
+	--user=${DNSCRYPT_USER} \
 	--ephemeral-keys
 Restart=on-abort
 


### PR DESCRIPTION
Thanks for improving privacy by adding the --ephemeral-keys param. Yet as it is, systemd errors on the missing "\" in the preceding line. Easily fixed though.