### PR TITLE
Changed DNSCRYPTURL to https endpoint

### DIFF
--- a/dnscrypt-autoinstall-redhat.sh
+++ b/dnscrypt-autoinstall-redhat.sh
@@ -27,7 +27,7 @@ LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
-DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
+DNSCRYPTURL="https://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
 LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | awk -F'(.tar|libsodium-)' '/libsodium-1/ {v=$2}; END {print v}')
 DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | awk -F'(.tar|proxy-)' '/proxy-1/ {v=$2}; END {print v}')

--- a/dnscrypt-autoinstall.sh
+++ b/dnscrypt-autoinstall.sh
@@ -28,7 +28,7 @@ LSODIUMINST=false
 DNSCRYPTINST=false
 DNSCRYPTCONF=false
 LSODIUMURL="https://download.libsodium.org/libsodium/releases"
-DNSCRYPTURL="http://download.dnscrypt.org/dnscrypt-proxy"
+DNSCRYPTURL="https://download.dnscrypt.org/dnscrypt-proxy"
 INITURL="https://raw.github.com/simonclausen/dnscrypt-autoinstall/master/init-scripts"
 LSODIUMVER=$(curl --retry 5 -L $LSODIUMURL | awk -F'(.tar|libsodium-)' '/libsodium-1/ {v=$2}; END {print v}')
 DNSCRYPTVER=$(curl --retry 5 -L $DNSCRYPTURL | awk -F'(.tar|proxy-)' '/proxy-1/ {v=$2}; END {print v}')


### PR DESCRIPTION
Updated DNSCRYPTURL to use an https endpoint rather than http. There is currently a valid Let's Encrypt cert at this endpoint - no reason not to use https.